### PR TITLE
Implement Logger and use it instead of glog - Issue #6

### DIFF
--- a/bndNil.go
+++ b/bndNil.go
@@ -56,5 +56,5 @@ func (bnd *bndNil) close() (err error) {
 	bnd.stmt = nil
 	bnd.ocibnd = nil
 	stmt.putBnd(bndIdxNil, bnd)
-return nil
+	return nil
 }

--- a/bndRset.go
+++ b/bndRset.go
@@ -79,5 +79,5 @@ func (bnd *bndRset) close() (err error) {
 	bnd.ocistmt = nil
 	bnd.value = nil
 	stmt.putBnd(bndIdxRset, bnd)
-return nil
+	return nil
 }

--- a/bndTimePtr.go
+++ b/bndTimePtr.go
@@ -84,5 +84,5 @@ func (bnd *bndTimePtr) close() (err error) {
 	bnd.ociDateTime = nil
 	bnd.value = nil
 	stmt.putBnd(bndIdxTimePtr, bnd)
-return nil
+	return nil
 }

--- a/bndUint16.go
+++ b/bndUint16.go
@@ -64,5 +64,5 @@ func (bnd *bndUint16) close() (err error) {
 	bnd.stmt = nil
 	bnd.ocibnd = nil
 	stmt.putBnd(bndIdxUint16, bnd)
-return nil
+	return nil
 }

--- a/bndUint16Ptr.go
+++ b/bndUint16Ptr.go
@@ -70,5 +70,5 @@ func (bnd *bndUint16Ptr) close() (err error) {
 	bnd.ocibnd = nil
 	bnd.value = nil
 	stmt.putBnd(bndIdxUint16Ptr, bnd)
-return nil
+	return nil
 }

--- a/bndUint16Slice.go
+++ b/bndUint16Slice.go
@@ -97,5 +97,5 @@ func (bnd *bndUint16Slice) close() (err error) {
 	bnd.ocibnd = nil
 	bnd.ociNumbers = nil
 	stmt.putBnd(bndIdxUint16Slice, bnd)
-return nil
+	return nil
 }

--- a/bndUint32.go
+++ b/bndUint32.go
@@ -64,5 +64,5 @@ func (bnd *bndUint32) close() (err error) {
 	bnd.stmt = nil
 	bnd.ocibnd = nil
 	stmt.putBnd(bndIdxUint32, bnd)
-return nil
+	return nil
 }

--- a/bndUint32Ptr.go
+++ b/bndUint32Ptr.go
@@ -70,5 +70,5 @@ func (bnd *bndUint32Ptr) close() (err error) {
 	bnd.ocibnd = nil
 	bnd.value = nil
 	stmt.putBnd(bndIdxUint32Ptr, bnd)
-return nil
+	return nil
 }

--- a/bndUint32Slice.go
+++ b/bndUint32Slice.go
@@ -97,5 +97,5 @@ func (bnd *bndUint32Slice) close() (err error) {
 	bnd.ocibnd = nil
 	bnd.ociNumbers = nil
 	stmt.putBnd(bndIdxUint32Slice, bnd)
-return nil
+	return nil
 }

--- a/bndUint64Ptr.go
+++ b/bndUint64Ptr.go
@@ -70,5 +70,5 @@ func (bnd *bndUint64Ptr) close() (err error) {
 	bnd.ocibnd = nil
 	bnd.value = nil
 	stmt.putBnd(bndIdxUint64Ptr, bnd)
-return nil
+	return nil
 }

--- a/bndUint64Slice.go
+++ b/bndUint64Slice.go
@@ -97,5 +97,5 @@ func (bnd *bndUint64Slice) close() (err error) {
 	bnd.ocibnd = nil
 	bnd.ociNumbers = nil
 	stmt.putBnd(bndIdxUint64Slice, bnd)
-return nil
+	return nil
 }

--- a/bndUint8Ptr.go
+++ b/bndUint8Ptr.go
@@ -70,5 +70,5 @@ func (bnd *bndUint8Ptr) close() (err error) {
 	bnd.ocibnd = nil
 	bnd.value = nil
 	stmt.putBnd(bndIdxUint8Ptr, bnd)
-return nil
+	return nil
 }

--- a/bndUint8Slice.go
+++ b/bndUint8Slice.go
@@ -97,5 +97,5 @@ func (bnd *bndUint8Slice) close() (err error) {
 	bnd.ocibnd = nil
 	bnd.ociNumbers = nil
 	stmt.putBnd(bndIdxUint8Slice, bnd)
-return nil
+	return nil
 }

--- a/conn.go
+++ b/conn.go
@@ -7,7 +7,6 @@ package ora
 import (
 	"container/list"
 	"database/sql/driver"
-	"github.com/golang/glog"
 )
 
 // Con is an Oracle connection associated with a server and session.
@@ -47,10 +46,10 @@ func (con *Con) Close() (err error) {
 	if err := con.checkIsOpen(); err != nil {
 		return err
 	}
-	glog.Infof("E%vC%v] Close", con.env.id, con.id)
+	Log.Infof("E%vC%v] Close", con.env.id, con.id)
 	defer func() {
 		if value := recover(); value != nil {
-			glog.Errorln(recoverMsg(value))
+			Log.Errorln(recoverMsg(value))
 			err = errRecover(value)
 		}
 
@@ -79,7 +78,7 @@ func (con *Con) Prepare(sql string) (driver.Stmt, error) {
 	if err := con.checkIsOpen(); err != nil {
 		return nil, err
 	}
-	glog.Infof("E%vC%v] Prepare", con.env.id, con.id)
+	Log.Infof("E%vC%v] Prepare", con.env.id, con.id)
 	stmt, err := con.ses.Prep(sql)
 	if err != nil {
 		return nil, err
@@ -94,7 +93,7 @@ func (con *Con) Begin() (driver.Tx, error) {
 	if err := con.checkIsOpen(); err != nil {
 		return nil, err
 	}
-	glog.Infof("E%vC%v] Begin", con.env.id, con.id)
+	Log.Infof("E%vC%v] Begin", con.env.id, con.id)
 	tx, err := con.ses.StartTx()
 	if err != nil {
 		return nil, err
@@ -107,6 +106,6 @@ func (con *Con) Ping() error {
 	if err := con.checkIsOpen(); err != nil {
 		return err
 	}
-	glog.Infof("E%vC%v] Ping", con.env.id, con.id)
+	Log.Infof("E%vC%v] Ping", con.env.id, con.id)
 	return con.srv.Ping()
 }

--- a/defBfile.go
+++ b/defBfile.go
@@ -24,7 +24,7 @@ type defBfile struct {
 func (def *defBfile) define(position int, rset *Rset) error {
 	def.rset = rset
 	r := C.OCIDefineByPos2(
-		def.rset.ocistmt,                   //OCIStmt     *stmtp,
+		def.rset.ocistmt,                        //OCIStmt     *stmtp,
 		&def.ocidef,                             //OCIDefine   **defnpp,
 		def.rset.stmt.ses.srv.env.ocierr,        //OCIError    *errhp,
 		C.ub4(position),                         //ub4         position,
@@ -109,5 +109,5 @@ func (def *defBfile) close() (err error) {
 	def.ocidef = nil
 	def.ociLobLocator = nil
 	rset.putDef(defIdxBfile, def)
-return nil
+	return nil
 }

--- a/defFloat32.go
+++ b/defFloat32.go
@@ -24,7 +24,7 @@ func (def *defFloat32) define(position int, isNullable bool, rset *Rset) error {
 	def.rset = rset
 	def.isNullable = isNullable
 	r := C.OCIDefineByPos2(
-		def.rset.ocistmt,            //OCIStmt     *stmtp,
+		def.rset.ocistmt,                 //OCIStmt     *stmtp,
 		&def.ocidef,                      //OCIDefine   **defnpp,
 		def.rset.stmt.ses.srv.env.ocierr, //OCIError    *errhp,
 		C.ub4(position),                  //ub4         position,

--- a/defFloat64.go
+++ b/defFloat64.go
@@ -24,7 +24,7 @@ func (def *defFloat64) define(position int, isNullable bool, rset *Rset) error {
 	def.rset = rset
 	def.isNullable = isNullable
 	r := C.OCIDefineByPos2(
-		def.rset.ocistmt,            //OCIStmt     *stmtp,
+		def.rset.ocistmt,                 //OCIStmt     *stmtp,
 		&def.ocidef,                      //OCIDefine   **defnpp,
 		def.rset.stmt.ses.srv.env.ocierr, //OCIError    *errhp,
 		C.ub4(position),                  //ub4         position,

--- a/defInt16.go
+++ b/defInt16.go
@@ -24,7 +24,7 @@ func (def *defInt16) define(position int, isNullable bool, rset *Rset) error {
 	def.rset = rset
 	def.isNullable = isNullable
 	r := C.OCIDefineByPos2(
-		def.rset.ocistmt,            //OCIStmt     *stmtp,
+		def.rset.ocistmt,                 //OCIStmt     *stmtp,
 		&def.ocidef,                      //OCIDefine   **defnpp,
 		def.rset.stmt.ses.srv.env.ocierr, //OCIError    *errhp,
 		C.ub4(position),                  //ub4         position,
@@ -93,5 +93,5 @@ func (def *defInt16) close() (err error) {
 	def.rset = nil
 	def.ocidef = nil
 	rset.putDef(defIdxInt16, def)
-return nil
+	return nil
 }

--- a/defInt32.go
+++ b/defInt32.go
@@ -24,7 +24,7 @@ func (def *defInt32) define(position int, isNullable bool, rset *Rset) error {
 	def.rset = rset
 	def.isNullable = isNullable
 	r := C.OCIDefineByPos2(
-		def.rset.ocistmt,            //OCIStmt     *stmtp,
+		def.rset.ocistmt,                 //OCIStmt     *stmtp,
 		&def.ocidef,                      //OCIDefine   **defnpp,
 		def.rset.stmt.ses.srv.env.ocierr, //OCIError    *errhp,
 		C.ub4(position),                  //ub4         position,
@@ -93,5 +93,5 @@ func (def *defInt32) close() (err error) {
 	def.rset = nil
 	def.ocidef = nil
 	rset.putDef(defIdxInt32, def)
-return nil
+	return nil
 }

--- a/defInt64.go
+++ b/defInt64.go
@@ -24,7 +24,7 @@ func (def *defInt64) define(position int, isNullable bool, rset *Rset) error {
 	def.rset = rset
 	def.isNullable = isNullable
 	r := C.OCIDefineByPos2(
-		def.rset.ocistmt,            //OCIStmt     *stmtp,
+		def.rset.ocistmt,                 //OCIStmt     *stmtp,
 		&def.ocidef,                      //OCIDefine   **defnpp,
 		def.rset.stmt.ses.srv.env.ocierr, //OCIError    *errhp,
 		C.ub4(position),                  //ub4         position,

--- a/defInt8.go
+++ b/defInt8.go
@@ -24,7 +24,7 @@ func (def *defInt8) define(position int, isNullable bool, rset *Rset) error {
 	def.rset = rset
 	def.isNullable = isNullable
 	r := C.OCIDefineByPos2(
-		def.rset.ocistmt,            //OCIStmt     *stmtp,
+		def.rset.ocistmt,                 //OCIStmt     *stmtp,
 		&def.ocidef,                      //OCIDefine   **defnpp,
 		def.rset.stmt.ses.srv.env.ocierr, //OCIError    *errhp,
 		C.ub4(position),                  //ub4         position,

--- a/defRowid.go
+++ b/defRowid.go
@@ -73,5 +73,5 @@ func (def *defRowid) close() (err error) {
 	def.ocidef = nil
 	clear(def.buf, 32)
 	rset.putDef(defIdxRowid, def)
-return nil
+	return nil
 }

--- a/defUint32.go
+++ b/defUint32.go
@@ -24,7 +24,7 @@ func (def *defUint32) define(position int, isNullable bool, rset *Rset) error {
 	def.rset = rset
 	def.isNullable = isNullable
 	r := C.OCIDefineByPos2(
-		def.rset.ocistmt,            //OCIStmt     *stmtp,
+		def.rset.ocistmt,                 //OCIStmt     *stmtp,
 		&def.ocidef,                      //OCIDefine   **defnpp,
 		def.rset.stmt.ses.srv.env.ocierr, //OCIError    *errhp,
 		C.ub4(position),                  //ub4         position,
@@ -93,5 +93,5 @@ func (def *defUint32) close() (err error) {
 	def.rset = nil
 	def.ocidef = nil
 	rset.putDef(defIdxUint32, def)
-return nil
+	return nil
 }

--- a/drv.go
+++ b/drv.go
@@ -15,7 +15,6 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
-	"github.com/golang/glog"
 	"sync"
 	"time"
 )
@@ -382,7 +381,7 @@ func GetDrv() *Drv {
 		var err error
 		_drv.sqlEnv, err = _drv.OpenEnv()
 		if err != nil {
-			glog.Errorln("GetDrv: ", err)
+			Log.Errorln("GetDrv: ", err)
 		}
 		_drv.sqlEnv.isSqlPkg = true
 		_drv.sqlEnv.stmtCfg.Rset.binaryFloat = F64
@@ -403,7 +402,7 @@ func (drv *Drv) OpenEnv() (*Env, error) {
 		drv.envId++
 		env.id = drv.envId
 	}
-	glog.Infof("OpenEnv %v", env.id)
+	Log.Infof("OpenEnv %v", env.id)
 
 	// OCI_DEFAULT  - The default value, which is non-UTF-16 encoding.
 	// OCI_THREADED - Uses threaded environment. Internal data structures not exposed to the user are protected from concurrent accesses by multiple threads.
@@ -445,7 +444,7 @@ func (drv *Drv) OpenEnv() (*Env, error) {
 //
 // Open is a member of the driver.Driver interface.
 func (drv *Drv) Open(conStr string) (driver.Conn, error) {
-	glog.Infoln("Open")
+	Log.Infoln("Open")
 	con, err := drv.sqlEnv.OpenCon(conStr)
 	if err != nil {
 		return nil, err

--- a/drvStmt.go
+++ b/drvStmt.go
@@ -4,10 +4,7 @@
 
 package ora
 
-import (
-	"database/sql/driver"
-	"github.com/golang/glog"
-)
+import "database/sql/driver"
 
 // DrvStmt is an Oracle statement associated with a session.
 //
@@ -33,7 +30,7 @@ func (ds *DrvStmt) Close() error {
 	if err := ds.checkIsOpen(); err != nil {
 		return err
 	}
-	glog.Infof("E%vS%vS%vS%v] Close", ds.stmt.ses.srv.env.id, ds.stmt.ses.srv.id, ds.stmt.ses.id, ds.stmt.id)
+	Log.Infof("E%vS%vS%vS%v] Close", ds.stmt.ses.srv.env.id, ds.stmt.ses.srv.id, ds.stmt.ses.id, ds.stmt.id)
 	return ds.stmt.Close()
 }
 
@@ -55,7 +52,7 @@ func (ds *DrvStmt) Exec(values []driver.Value) (result driver.Result, err error)
 	if err := ds.checkIsOpen(); err != nil {
 		return nil, err
 	}
-	glog.Infof("E%vS%vS%vS%v] Exec", ds.stmt.ses.srv.env.id, ds.stmt.ses.srv.id, ds.stmt.ses.id, ds.stmt.id)
+	Log.Infof("E%vS%vS%vS%v] Exec", ds.stmt.ses.srv.env.id, ds.stmt.ses.srv.id, ds.stmt.ses.id, ds.stmt.id)
 	params := make([]interface{}, len(values))
 	for n, _ := range values {
 		params[n] = values[n]
@@ -77,7 +74,7 @@ func (ds *DrvStmt) Query(values []driver.Value) (driver.Rows, error) {
 	if err := ds.checkIsOpen(); err != nil {
 		return nil, err
 	}
-	glog.Infof("E%vS%vS%vS%v] Query", ds.stmt.ses.srv.env.id, ds.stmt.ses.srv.id, ds.stmt.ses.id, ds.stmt.id)
+	Log.Infof("E%vS%vS%vS%v] Query", ds.stmt.ses.srv.env.id, ds.stmt.ses.srv.id, ds.stmt.ses.id, ds.stmt.id)
 	params := make([]interface{}, len(values))
 	for n, _ := range values {
 		params[n] = values[n]

--- a/env.go
+++ b/env.go
@@ -12,7 +12,6 @@ import "C"
 import (
 	"container/list"
 	"fmt"
-	"github.com/golang/glog"
 	"strings"
 	"unsafe"
 )
@@ -66,11 +65,11 @@ func (env *Env) Close() (err error) {
 	if err := env.checkIsOpen(); err != nil {
 		return err
 	}
-	glog.Infof("E%v] Close", env.id)
+	Log.Infof("E%v] Close", env.id)
 	errs := env.drv.listPool.Get().(*list.List)
 	defer func() {
 		if value := recover(); value != nil {
-			glog.Errorln(recoverMsg(value))
+			Log.Errorln(recoverMsg(value))
 			errs.PushBack(errRecover(value))
 		}
 
@@ -113,7 +112,7 @@ func (env *Env) OpenSrv(dbname string) (*Srv, error) {
 	if err := env.checkIsOpen(); err != nil {
 		return nil, err
 	}
-	glog.Infof("E%v] OpenSrv (dbname %v)", env.id, dbname)
+	Log.Infof("E%v] OpenSrv (dbname %v)", env.id, dbname)
 	// allocate server handle
 	ocisrv, err := env.allocOciHandle(C.OCI_HTYPE_SERVER)
 	if err != nil {
@@ -148,7 +147,7 @@ func (env *Env) OpenSrv(dbname string) (*Srv, error) {
 		env.srvId++
 		srv.id = env.srvId
 	}
-	glog.Infof("E%v] OpenSrv (srvId %v)", env.id, srv.id)
+	Log.Infof("E%v] OpenSrv (srvId %v)", env.id, srv.id)
 	srv.env = env
 	srv.ocisrv = (*C.OCIServer)(ocisrv)
 	srv.ocisvcctx = (*C.OCISvcCtx)(ocisvcctx)
@@ -168,7 +167,7 @@ func (env *Env) OpenCon(str string) (*Con, error) {
 	if err := env.checkIsOpen(); err != nil {
 		return nil, err
 	}
-	glog.Infof("E%v] OpenCon", env.id)
+	Log.Infof("E%v] OpenCon", env.id)
 	// parse connection string
 	var username string
 	var password string
@@ -177,7 +176,7 @@ func (env *Env) OpenCon(str string) (*Con, error) {
 	str = strings.Replace(str, "/", " / ", 1)
 	str = strings.Replace(str, "@", " @ ", 1)
 	_, err := fmt.Sscanf(str, "%s / %s @ %s", &username, &password, &dbname)
-	glog.Infof("E%v] OpenCon (dbname %v, username %v)", env.id, dbname, username)
+	Log.Infof("E%v] OpenCon (dbname %v, username %v)", env.id, dbname, username)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +196,7 @@ func (env *Env) OpenCon(str string) (*Con, error) {
 		env.conId++
 		con.id = env.conId
 	}
-	glog.Infof("E%v] OpenCon (conId %v)", env.id, con.id)
+	Log.Infof("E%v] OpenCon (conId %v)", env.id, con.id)
 	con.env = env
 	con.srv = srv
 	con.ses = ses

--- a/glg/glg.go
+++ b/glg/glg.go
@@ -1,0 +1,16 @@
+// Copyright 2015 Tamás Gulácsi. All rights reserved.
+// Use of this source code is governed by The MIT License
+// found in the accompanying LICENSE file.
+
+package glg
+
+import "github.com/golang/glog"
+
+var Log = gLogger{}
+
+type gLogger struct{}
+
+func (s gLogger) Infof(format string, args ...interface{})  { glog.Infof(format, args...) }
+func (s gLogger) Infoln(args ...interface{})                { glog.Infoln(args...) }
+func (s gLogger) Errorf(format string, args ...interface{}) { glog.Errorf(format, args...) }
+func (s gLogger) Errorln(args ...interface{})               { glog.Errorln(args...) }

--- a/lg15/lg15.go
+++ b/lg15/lg15.go
@@ -1,0 +1,39 @@
+// Copyright 2015 Tamás Gulácsi. All rights reserved.
+// Use of this source code is governed by The MIT License
+// found in the accompanying LICENSE file.
+
+package lg15
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/inconshreveable/log15.v2"
+)
+
+var Log = lgr{log15.New("lib", "ora")}
+
+type lgr struct {
+	log15.Logger
+}
+
+func (s lgr) Infof(format string, args ...interface{})  { s.Info(fmt.Sprintf(format, args...)) }
+func (s lgr) Infoln(args ...interface{})                { s.Info(strings.Join(asStrings(args), " ")) }
+func (s lgr) Errorf(format string, args ...interface{}) { s.Error(fmt.Sprintf(format, args...)) }
+func (s lgr) Errorln(args ...interface{})               { s.Error(strings.Join(asStrings(args), " ")) }
+
+func asStrings(args ...interface{}) []string {
+	arr := make([]string, len(args))
+	for i, a := range args {
+		if s, ok := a.(string); ok {
+			arr[i] = s
+			continue
+		}
+		if s, ok := a.(fmt.Stringer); ok {
+			arr[i] = s.String()
+			continue
+		}
+		arr[i] = fmt.Sprintf("%v", a)
+	}
+	return arr
+}

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,35 @@
+// Copyright 2015 Tamás Gulácsi. All rights reserved.
+// Use of this source code is governed by The MIT License
+// found in the accompanying LICENSE file.
+
+package ora
+
+import "log"
+
+// Log can be replaced with any type implementing the Logger interface.
+//
+// The default implementation uses the standard lib's log package.
+//
+// For a glog-based implementation, see github.com/ranaian/ora/glg.
+// ora.Log = glg.Log
+//
+// For an gopkg.in/inconshreveable/log15.v2-based, see github.com/ranaian/ora/lg15.
+// ora.Log = lg15.Log
+var Log Logger = stdLog{}
+
+// Logger interface is for logging.
+type Logger interface {
+	Infof(format string, args ...interface{})
+	Infoln(args ...interface{})
+	Errorf(format string, args ...interface{})
+	Errorln(args ...interface{})
+}
+
+var _ Logger = stdLog{}
+
+type stdLog struct{}
+
+func (s stdLog) Infof(format string, args ...interface{})  { log.Printf(format, args...) }
+func (s stdLog) Infoln(args ...interface{})                { log.Println(args...) }
+func (s stdLog) Errorf(format string, args ...interface{}) { log.Printf("ERROR "+format, args...) }
+func (s stdLog) Errorln(args ...interface{})               { log.Println(append([]interface{}{"ERROR "}, args...)...) }

--- a/rset.go
+++ b/rset.go
@@ -10,7 +10,6 @@ package ora
 import "C"
 import (
 	"container/list"
-	"github.com/golang/glog"
 	"io"
 	"unsafe"
 )
@@ -55,7 +54,7 @@ func (rset *Rset) close() (err error) {
 	if err := rset.checkIsOpen(); err != nil {
 		return err
 	}
-	glog.Infof("E%vS%vS%vS%vR%v] close", rset.stmt.ses.srv.env.id, rset.stmt.ses.srv.id, rset.stmt.ses.id, rset.stmt.id, rset.id)
+	Log.Infof("E%vS%vS%vS%vR%v] close", rset.stmt.ses.srv.env.id, rset.stmt.ses.srv.id, rset.stmt.ses.id, rset.stmt.id, rset.id)
 	errs := rset.stmt.ses.srv.env.drv.listPool.Get().(*list.List)
 	defer func() {
 		if value := recover(); value != nil {
@@ -203,7 +202,7 @@ func (rset *Rset) open(stmt *Stmt, ocistmt *C.OCIStmt) error {
 	rset.ocistmt = ocistmt
 	rset.Index = -1
 	rset.Err = nil
-	glog.Infof("E%vS%vS%vS%vR%v] open", rset.stmt.ses.srv.env.id, rset.stmt.ses.srv.id, rset.stmt.ses.id, rset.stmt.id, rset.id)
+	Log.Infof("E%vS%vS%vS%vR%v] open", rset.stmt.ses.srv.env.id, rset.stmt.ses.srv.id, rset.stmt.ses.id, rset.stmt.id, rset.id)
 	// get the implcit select-list describe information; no server round-trip
 	r := C.OCIStmtExecute(
 		rset.stmt.ses.srv.ocisvcctx,  //OCISvcCtx           *svchp,

--- a/ses.go
+++ b/ses.go
@@ -13,7 +13,6 @@ import (
 	"bytes"
 	"container/list"
 	"fmt"
-	"github.com/golang/glog"
 	"strings"
 	"unsafe"
 )
@@ -69,11 +68,11 @@ func (ses *Ses) Close() (err error) {
 	if err := ses.checkIsOpen(); err != nil {
 		return err
 	}
-	glog.Infof("E%vS%vS%v] Close", ses.srv.env.id, ses.srv.id, ses.id)
+	Log.Infof("E%vS%vS%v] Close", ses.srv.env.id, ses.srv.id, ses.id)
 	errs := ses.srv.env.drv.listPool.Get().(*list.List)
 	defer func() {
 		if value := recover(); value != nil {
-			glog.Errorln(recoverMsg(value))
+			Log.Errorln(recoverMsg(value))
 			errs.PushBack(errRecover(value))
 		}
 
@@ -158,7 +157,7 @@ func (ses *Ses) Prep(sql string, gcts ...GoColumnType) (*Stmt, error) {
 	if err := ses.checkIsOpen(); err != nil {
 		return nil, err
 	}
-	glog.Infof("E%vS%vS%v] Prep: %v", ses.srv.env.id, ses.srv.id, ses.id, sql)
+	Log.Infof("E%vS%vS%v] Prep: %v", ses.srv.env.id, ses.srv.id, ses.id, sql)
 	// allocate statement handle
 	ocistmt, err := ses.srv.env.allocOciHandle(C.OCI_HTYPE_STMT)
 	if err != nil {
@@ -385,7 +384,7 @@ func (ses *Ses) StartTx() (*Tx, error) {
 	if err := ses.checkIsOpen(); err != nil {
 		return nil, err
 	}
-	glog.Infof("E%vS%vS%v] StartTx", ses.srv.env.id, ses.srv.id, ses.id)
+	Log.Infof("E%vS%vS%v] StartTx", ses.srv.env.id, ses.srv.id, ses.id)
 	// start transaction
 	// the number of seconds the transaction can be inactive
 	// before it is automatically terminated by the system.

--- a/srv.go
+++ b/srv.go
@@ -12,7 +12,6 @@ import "C"
 import (
 	"container/list"
 	"fmt"
-	"github.com/golang/glog"
 	"unsafe"
 )
 
@@ -23,11 +22,11 @@ type Srv struct {
 	ocisvcctx *C.OCISvcCtx
 	ocisrv    *C.OCIServer
 
-	sesId      uint64
-	sess       *list.List
-	elem       *list.Element
+	sesId   uint64
+	sess    *list.List
+	elem    *list.Element
 	stmtCfg StmtCfg
-	dbname     string
+	dbname  string
 }
 
 // NumSes returns the number of open Oracle sessions.
@@ -61,11 +60,11 @@ func (srv *Srv) Close() (err error) {
 	if err := srv.checkIsOpen(); err != nil {
 		return err
 	}
-	glog.Infof("E%vS%v] Close", srv.env.id, srv.id)
+	Log.Infof("E%vS%v] Close", srv.env.id, srv.id)
 	errs := srv.env.drv.listPool.Get().(*list.List)
 	defer func() {
 		if value := recover(); value != nil {
-			glog.Errorln(recoverMsg(value))
+			Log.Errorln(recoverMsg(value))
 			errs.PushBack(errRecover(value))
 		}
 
@@ -111,7 +110,7 @@ func (srv *Srv) OpenSes(username string, password string) (*Ses, error) {
 	if err := srv.checkIsOpen(); err != nil {
 		return nil, err
 	}
-	glog.Infof("E%vS%v] OpenSes (username %v)", srv.env.id, srv.id, username)
+	Log.Infof("E%vS%v] OpenSes (username %v)", srv.env.id, srv.id, username)
 	// allocate session handle
 	ocises, err := srv.env.allocOciHandle(C.OCI_HTYPE_SESSION)
 	if err != nil {
@@ -179,7 +178,7 @@ func (srv *Srv) Ping() error {
 	if err := srv.checkIsOpen(); err != nil {
 		return err
 	}
-	glog.Infof("E%vS%v] Ping", srv.env.id, srv.id)
+	Log.Infof("E%vS%v] Ping", srv.env.id, srv.id)
 	r := C.OCIPing(
 		srv.ocisvcctx,  //OCISvcCtx     *svchp,
 		srv.env.ocierr, //OCIError      *errhp,
@@ -197,7 +196,7 @@ func (srv *Srv) Version() (string, error) {
 	if err := srv.checkIsOpen(); err != nil {
 		return "", err
 	}
-	glog.Infof("E%vS%v] Version", srv.env.id, srv.id)
+	Log.Infof("E%vS%v] Version", srv.env.id, srv.id)
 	var buf [512]C.char
 	r := C.OCIServerVersion(
 		unsafe.Pointer(srv.ocisrv),            //void         *hndlp,

--- a/stmt.go
+++ b/stmt.go
@@ -11,7 +11,6 @@ package ora
 import "C"
 import (
 	"container/list"
-	"github.com/golang/glog"
 	"reflect"
 	"strings"
 	"time"
@@ -73,11 +72,11 @@ func (stmt *Stmt) Close() (err error) {
 	if err := stmt.checkIsOpen(); err != nil {
 		return err
 	}
-	glog.Infof("E%vS%vS%vS%v] Close", stmt.ses.srv.env.id, stmt.ses.srv.id, stmt.ses.id, stmt.id)
+	Log.Infof("E%vS%vS%vS%v] Close", stmt.ses.srv.env.id, stmt.ses.srv.id, stmt.ses.id, stmt.id)
 	errs := stmt.ses.srv.env.drv.listPool.Get().(*list.List)
 	defer func() {
 		if value := recover(); value != nil {
-			glog.Errorln(recoverMsg(value))
+			Log.Errorln(recoverMsg(value))
 			errs.PushBack(errRecover(value))
 		}
 


### PR DESCRIPTION
Include three implementations: standard log package (the default), glog
(under glg) and log15 (under lg15).

Configurable by setting the Log variable to something implementing the
Logger interface.
The Logger interface is tha bare minimal: Infof, Infoln, Errorf and
Errorln.