### PR TITLE
Fix Test_clob_string_db read shortness

### DIFF
--- a/tstlg/tstlg.go
+++ b/tstlg/tstlg.go
@@ -1,0 +1,28 @@
+// Copyright 2015 Rana Ian. All rights reserved.
+// Use of this source code is governed by The MIT License
+// found in the accompanying LICENSE file.
+
+package tstlg
+
+import "testing"
+
+func New(t *testing.T) Tst {
+	return Tst{t}
+}
+
+type Tst struct {
+	*testing.T
+}
+
+func (t Tst) Infof(format string, v ...interface{}) {
+	t.Logf("ORA I "+format, v...)
+}
+func (t Tst) Infoln(v ...interface{}) {
+	t.Logf("ORA I ", v...)
+}
+func (t Tst) Errorf(format string, v ...interface{}) {
+	t.Logf("ORA E "+format, v...)
+}
+func (t Tst) Errorln(v ...interface{}) {
+	t.Logf("ORA E ", v...)
+}

--- a/z_db_test.go
+++ b/z_db_test.go
@@ -7,6 +7,8 @@ package ora
 import (
 	"fmt"
 	"testing"
+
+	"github.com/ranaian/ora/tstlg"
 )
 
 func Test_numberP38S0Identity_db(t *testing.T) {
@@ -180,6 +182,7 @@ func Test_longNull_string_db(t *testing.T) {
 }
 
 func Test_clob_string_db(t *testing.T) {
+	Log = tstlg.New(t)
 	testBindDefineDB(gen_string(), t, clob)
 }
 

--- a/z_db_test.go
+++ b/z_db_test.go
@@ -10,10 +10,19 @@ import (
 )
 
 func Test_numberP38S0Identity_db(t *testing.T) {
-	tableName := createTableDB(testDb, t, numberP38S0Identity, varchar2C48)
+	tableName := tableName()
+	stmt, err := testDb.Prepare(createTableSql(tableName, 1, numberP38S0Identity, varchar2C48))
+	if err == nil {
+		defer stmt.Close()
+		_, err = stmt.Exec()
+	}
+	if err != nil {
+		t.Skipf("SKIP create table with identity: %v", err)
+		return
+	}
 	defer dropTableDB(testDb, t, tableName)
 
-	stmt, err := testDb.Prepare(fmt.Sprintf("insert into %v (c2) values ('go') returning c1 into :c1", tableName))
+	stmt, err = testDb.Prepare(fmt.Sprintf("insert into %v (c2) values ('go') returning c1 into :c1", tableName))
 	defer stmt.Close()
 
 	// pass nil to Exec when using 'returning into' clause with sql.DB

--- a/z_oracle_test.go
+++ b/z_oracle_test.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -749,12 +750,36 @@ func tableName() string {
 	return "t" + strconv.Itoa(testTableId)
 }
 
+func getStack(stripHeadCalls int) string {
+	buf := make([]byte, 4096)
+	n := runtime.Stack(buf, false)
+	buf = buf[:n]
+	i := bytes.IndexByte(buf, '\n')
+	if i < 0 {
+		return string(buf)
+	}
+	var prefix string
+	if bytes.Contains(buf[:i], []byte("goroutine")) {
+		prefix, buf = string(buf[:i+1]), buf[i+1:]
+	}
+Loop:
+	for stripHeadCalls > 0 {
+		stripHeadCalls--
+		for i := 0; i < 2; i++ {
+			if j := bytes.IndexByte(buf, '\n'); j < 0 {
+				break Loop
+			} else {
+				buf = buf[j+1:]
+			}
+		}
+	}
+	return prefix + string(buf)
+}
+
 func testErr(err error, t *testing.T, expectedErrs ...error) {
 	if err != nil {
 		if expectedErrs == nil {
-			buf := make([]byte, 4096)
-			n := runtime.Stack(buf, false)
-			t.Fatalf("%v: %s", err, buf[:n])
+			t.Fatalf("%v: %s", err, getStack(1))
 		} else {
 			var isSkipping bool
 			for _, expectedErr := range expectedErrs {
@@ -1749,7 +1774,7 @@ func compare_string(expected interface{}, actual interface{}, t *testing.T) {
 		}
 	}
 	if e != a {
-		t.Fatalf("expected(%v), actual(%v)", e, a)
+		t.Fatalf("expected(%v), actual(%v)\n%s", e, a, getStack(2))
 	}
 }
 
@@ -2454,10 +2479,21 @@ func gen_OraBoolSlice(isNull bool) interface{} {
 	return expected
 }
 
+var (
+	_gen_bytes    []byte
+	_gen_bytes_mu sync.Mutex
+)
+
 func gen_bytes(length int) []byte {
-	values := make([]byte, length)
+	_gen_bytes_mu.Lock()
+	defer _gen_bytes_mu.Unlock()
+	if len(_gen_bytes) >= length {
+		return _gen_bytes[:length:length]
+	}
+	values := make([]byte, length-len(_gen_bytes))
 	rand.Read(values)
-	return values
+	_gen_bytes = append(_gen_bytes, values...)
+	return _gen_bytes[:length:length]
 }
 
 func gen_OraBytes(length int, isNull bool) Binary {

--- a/z_oracle_test.go
+++ b/z_oracle_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -751,7 +752,9 @@ func tableName() string {
 func testErr(err error, t *testing.T, expectedErrs ...error) {
 	if err != nil {
 		if expectedErrs == nil {
-			t.Fatal(err)
+			buf := make([]byte, 4096)
+			n := runtime.Stack(buf, false)
+			t.Fatalf("%v: %s", err, buf[:n])
 		} else {
 			var isSkipping bool
 			for _, expectedErr := range expectedErrs {


### PR DESCRIPTION
OCILobRead2 with OCI_ONE_PIECE, as OCI_START_PIECE + OCI_NEXT_PIECE resulted in only the first 12 bytes.

And add tstlg to be able to see the logs in tests.


gthomas@waterhouse:~/src/github.com/ranaian/ora$ go test -run=Test_clob_string_db -vRead environment variable GO_ORA_DRV_TEST_DB = '(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=git.gthomas.eu)(PORT=49161)))(CONNECT_DATA=(SERVICE_NAME=xe)))'
Read environment variable GO_ORA_DRV_TEST_USERNAME = 'test'
Read environment variable GO_ORA_DRV_TEST_PASSWORD = 'test'
Read session time zone from database...
Dropping previous tables...
=== RUN   Test_clob_string_db
--- PASS: Test_clob_string_db (0.18s)
        tstlg.go:21: ORA I %!(EXTRA string=Open)
        tstlg.go:18: ORA I E1] OpenCon
        tstlg.go:18: ORA I E1] OpenCon (dbname (DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=git.gthomas.eu)(PORT=49161)))(CONNECT_DATA=(SERVICE_NAME=xe))), username test)
        tstlg.go:18: ORA I E1] OpenSrv (dbname (DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=git.gthomas.eu)(PORT=49161)))(CONNECT_DATA=(SERVICE_NAME=xe))))
        tstlg.go:18: ORA I E1] OpenSrv (srvId 2)
        tstlg.go:18: ORA I E1S2] OpenSes (username test)
        tstlg.go:18: ORA I E1] OpenCon (conId 2)
        tstlg.go:18: ORA I E1C2] Prepare
        tstlg.go:18: ORA I E1S2S1] Prep: create table t1 (c1 clob not null)
        tstlg.go:18: ORA I E1S2S1S1] Exec
        tstlg.go:18: ORA I E1S2S1S1] Close
        tstlg.go:18: ORA I E1S2S1S1] Close
        tstlg.go:18: ORA I E1C2] Prepare
        tstlg.go:18: ORA I E1S2S1] Prep: insert into t1 (c1) values (:c1)
        tstlg.go:18: ORA I E1S2S1S1] Exec
        tstlg.go:18: ORA I E1C2] Prepare
        tstlg.go:18: ORA I E1S2S1] Prep: select c1 from t1
        tstlg.go:18: ORA I E1S2S1S1] Query
        tstlg.go:18: ORA I E1S2S1S1R0] open
        tstlg.go:18: ORA I LobRead amt=48
        tstlg.go:18: ORA I copy writeIndex=0 amt=12 len=48
        tstlg.go:18: ORA I LobRead amt=36
        tstlg.go:18: ORA I copy writeIndex=12 amt=9 len=48
        tstlg.go:18: ORA I LobRead amt=27
        tstlg.go:18: ORA I copy writeIndex=21 amt=6 len=48
        tstlg.go:18: ORA I LobRead amt=21
        tstlg.go:18: ORA I copy writeIndex=27 amt=5 len=48
        tstlg.go:18: ORA I LobRead amt=16
        tstlg.go:18: ORA I copy writeIndex=32 amt=4 len=48
        tstlg.go:18: ORA I LobRead amt=12
        tstlg.go:18: ORA I copy writeIndex=36 amt=3 len=48
        tstlg.go:18: ORA I LobRead amt=9
        tstlg.go:18: ORA I copy writeIndex=39 amt=2 len=48
        tstlg.go:18: ORA I LobRead amt=7
        tstlg.go:18: ORA I copy writeIndex=41 amt=1 len=48
        tstlg.go:18: ORA I LobRead amt=6
        tstlg.go:18: ORA I copy writeIndex=42 amt=1 len=48
        tstlg.go:18: ORA I LobRead amt=5
        tstlg.go:18: ORA I copy writeIndex=43 amt=1 len=48
        tstlg.go:18: ORA I LobRead amt=4
        tstlg.go:18: ORA I copy writeIndex=44 amt=1 len=48
        tstlg.go:18: ORA I LobRead amt=3
        tstlg.go:18: ORA I copy writeIndex=45 amt=3 len=48
        tstlg.go:18: ORA I E1S2S1S1] Close
        tstlg.go:18: ORA I E1S2S1S1] Close
        tstlg.go:18: ORA I E1S2S1S1R0] close
        tstlg.go:18: ORA I E1S2S1S1] Close
        tstlg.go:18: ORA I E1S2S1S1] Close
        tstlg.go:18: ORA I E1C2] Prepare
        tstlg.go:18: ORA I E1S2S1] Prep: drop table t1
        tstlg.go:18: ORA I E1S2S1S1] Exec
        tstlg.go:18: ORA I E1S2S1S1] Close
        tstlg.go:18: ORA I E1S2S1S1] Close
PASS
ok      github.com/ranaian/ora  0.453s
