### PR TITLE
Make Example run on 11.2.0.2.0

### DIFF
--- a/z_db_test.go
+++ b/z_db_test.go
@@ -7,8 +7,6 @@ package ora
 import (
 	"fmt"
 	"testing"
-
-	"github.com/ranaian/ora/tstlg"
 )
 
 func Test_numberP38S0Identity_db(t *testing.T) {
@@ -182,7 +180,7 @@ func Test_longNull_string_db(t *testing.T) {
 }
 
 func Test_clob_string_db(t *testing.T) {
-	Log = tstlg.New(t)
+	enableLogging(t)
 	testBindDefineDB(gen_string(), t, clob)
 }
 
@@ -207,6 +205,7 @@ func Test_charB1Null_bool_true_db(t *testing.T) {
 }
 
 func Test_charC1_bool_true_db(t *testing.T) {
+	enableLogging(t)
 	testBindDefineDB(gen_boolTrue(), t, charC1)
 }
 

--- a/z_oracle_test.go
+++ b/z_oracle_test.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/ranaian/ora/tstlg"
 )
 
 type oracleColumnType string
@@ -164,6 +166,18 @@ func init() {
 	if err != nil {
 		fmt.Println("initError: ", err)
 	}
+}
+
+var enableLoggingMu sync.Mutex
+
+func enableLogging(t *testing.T) {
+	enableLoggingMu.Lock()
+	defer enableLoggingMu.Unlock()
+	if t != nil {
+		Log = tstlg.New(t)
+		return
+	}
+	Log = nil
 }
 
 func testIterations() int {
@@ -1827,7 +1841,7 @@ func compare_bool(expected interface{}, actual interface{}, t *testing.T) {
 			if aOraOk {
 				a = aOra.Value
 			} else {
-				t.Fatalf("Unable to cast actual value to bool, *bool, ora.Bool. (%v, %v)", reflect.TypeOf(actual), actual)
+				t.Fatalf("Unable to cast actual value to bool, *bool, ora.Bool. (%v, %v): %s", reflect.TypeOf(actual), actual, getStack(2))
 			}
 		}
 	}


### PR DESCRIPTION
Only 12c has "GENERATED ALWAYS AS IDENTITY" column default.

("go test" runs the Examples, too)